### PR TITLE
Support Catch node for owserver errors

### DIFF
--- a/owfs.js
+++ b/owfs.js
@@ -52,9 +52,9 @@ module.exports = function(RED) {
                                 node.send(msg);
                             } else {
                                 if ('msg' in error) {
-                                    node.error(error.msg);
+                                    node.error(error.msg, msg);
                                 } else {
-                                    node.error(error);
+                                    node.error(error, msg);
                                 }
                             }
                             callback();


### PR DESCRIPTION
Hopefully a fix for Issue #6.
It seems too easy, but Catch nodes now appear to work correctly when the owserver has a problem accessing the sensor, or if it the owfs node cannot access the server.