### PR TITLE
Allow host and port to be passed in via msg.host and msg.port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ One or more owfs paths can be selected in the node edit dialog. Upon receiving a
 
 Alternatively a device path can be specified in the **msg.topic** field, for example <code>28.0080BE21AA00/temperature</code>. This will override any paths selected in the edit dialog.
 
+In addition the owserver port and/or host can be specified in **msg.host** and **msg.port**, overriding any settings in the node configuration.
+
 To trigger reading sensors periodically, use an Inject node to send messages every X seconds.
 
 

--- a/owfs.html
+++ b/owfs.html
@@ -17,7 +17,7 @@
 
 <script type="text/x-red" data-template-name="owfs">
     <div class="form-row">
-        <label for="node-input-]"><i class="icon-globe"></i> Host</label>
+        <label for="node-input-host"><i class="icon-globe"></i> Host</label>
         <input type="text" id="node-input-host" placeholder="localhost" />
     </div>
     <div class="form-row">
@@ -53,6 +53,7 @@
     <p>A node for talking to <a href="http://www.maximintegrated.com/en/products/comms/one-wire.html" target="_new">1-wire</a> devices using an <a href="http://owfs.org/" target="_new">owfs</a> <a href="http://owfs.org/index.php?page=owserver" target="_new">owserver</a> instance.</p>
     <p>One or more owfs paths can be selected in the node edit dialog. Upon receiving a message on the input the node, it will request each of the values in turn from owfs and places the reading in <b>msg.payload</b>.</p>
     <p>Alternatively a device path can be specified in the <b>msg.topic</b> field, for example <code>28.0080BE21AA00/temperature</code>. This will override any paths selected in the edit dialog.</p>
+    <p>In addition the owserver port and/or host can be specified in <b>msg.host</b> and <b>msg.port</b>, overriding any settings in the node configuration.</p>
     <p>To trigger reading sensors periodically, use an Inject node to send messages every X seconds.</p>
 </script>
 
@@ -61,8 +62,8 @@
         category: 'function',
         defaults: {
             name: {value:""},
-            host: {value:"localhost",required:true},
-            port: {value:4304,required:true,validate:RED.validators.number()},
+            host: {value:"localhost"},
+            port: {value:4304,validate:RED.validators.regex(/^[0-9]*$/)},
             paths: {value:[]}
         },
         color:"#C0DEED",

--- a/owfs.js
+++ b/owfs.js
@@ -36,34 +36,38 @@ module.exports = function(RED) {
                 paths = [msg.topic];
             }
 
-            if (paths && paths.length > 0) {
-                // Query owfs for each path, one at a time
-                async.eachSeries(paths, function(path, callback) {
-                    client.read(path, function(error, result) {
-                        if (!error) {
-                            if (result.match(/^\-?\d+\.\d+$/)) {
-                                msg.payload = parseFloat(result);
-                            } else if (result.match(/^\-?\d+$/)) {
-                                msg.payload = parseInt(result);
-                            } else {
-                                msg.payload = result;
-                            }
-                            msg.topic = path;
-                            msg.timestamp = Date.now();
-                            node.send(msg);
-                        } else {
-                            if ('msg' in error) {
-                                node.error(error.msg, msg);
-                            } else {
-                                node.error(error, msg);
-                            }
-                        }
-                        callback();
-                    });
-                });
-            } else {
-                node.warn("no owfs paths configured and msg.topic is empty");
-            }
+            if (host && host.length > 0 && port && port.length > 0) {
+              if (paths && paths.length > 0) {
+                  // Query owfs for each path, one at a time
+                  async.eachSeries(paths, function(path, callback) {
+                      client.read(path, function(error, result) {
+                          if (!error) {
+                              if (result.match(/^\-?\d+\.\d+$/)) {
+                                  msg.payload = parseFloat(result);
+                              } else if (result.match(/^\-?\d+$/)) {
+                                  msg.payload = parseInt(result);
+                              } else {
+                                  msg.payload = result;
+                              }
+                              msg.topic = path;
+                              msg.timestamp = Date.now();
+                              node.send(msg);
+                          } else {
+                              if ('msg' in error) {
+                                  node.error(error.msg, msg);
+                              } else {
+                                  node.error(error, msg);
+                              }
+                          }
+                          callback();
+                      });
+                  });
+              } else {
+                  node.warn("no owfs paths configured and msg.topic is empty");
+              }
+          } else {
+              node.warn("missing host or port configuration and not provided by msg.host and msg.port");
+          }
         });
     }
     RED.nodes.registerType("owfs",OwfsNode);

--- a/owfs.js
+++ b/owfs.js
@@ -30,7 +30,6 @@ module.exports = function(RED) {
         node.on("input", function(msg) {
             var host = msg.host  ||  node.host;
             var port = msg.port  ||  node.port;
-            //node.log("owserver " + host + ":" + port);
             var client = new owfs.Client(host, port);
             var paths = node.paths;
             if (msg.topic) {


### PR DESCRIPTION
 In order to be able to use the node in a subflow with different owserver hosts I have made changes to allow the host and/or port to be passed in via msg.host and msg.port.   I think this may be generally useful and should not affect any existing flows.  I have tested that these work if the fields are left empty in the node, and also that the msg properties over-ride those in the node when they are supplied.
Hopefully this will be considered a worthwhile enhancement.