### PR TITLE
Add `aux` node to blacklist to enable more hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Hardare Tested
 * [SWE1: Temperature Sensor](http://www.sheepwalkelectronics.co.uk/product_info.php?cPath=23&products_id=53)
 * [SWE3: Humidity Sensor Module](http://www.sheepwalkelectronics.co.uk/product_info.php?cPath=23&products_id=55)
 * [SWE4: Dual Channel I/O Module](http://www.sheepwalkelectronics.co.uk/product_info.php?cPath=23&products_id=59)
-
+* [DS1822 Econo 1-Wire Digital Thermometer](http://www.maximintegrated.com/en/products/DS1822)
+* [DS2401 Silicon Serial Number](http://www.maximintegrated.com/en/products/DS2401)
+* [DS2406 Dual Addressable Switch Plus 1Kb Memory](http://www.maximintegrated.com/en/products/DS2406)
+* [DS2408 1-Wire 8-Channel Addressable Switch](http://www.maximintegrated.com/en/products/DS2408)
+* [DS2438 Smart Battery Monitor](http://www.maximintegrated.com/en/products/DS2438) (often used as a temperature and humidity sensor)
 
 
 [Node-RED]:  http://nodered.org/

--- a/owfs.js
+++ b/owfs.js
@@ -155,7 +155,7 @@ module.exports = function(RED) {
             });
         }
 
-        var blacklist = new RegExp("/(?:address|crc8|errata/|family|id|locator|pages/|r_[a-z]+)$");
+        var blacklist = new RegExp("/(?:address|crc8|errata/|family|id|locator|pages/|aux/|r_[a-z]+)$");
         var client = new owfs.Client(req.query.host, req.query.port);
 
         recursiveDirall(client, "/", blacklist)


### PR DESCRIPTION
This change blacklists `aux/` owfs branches to make hardware like the DS2406 Dual Addressable Switch Plus 1Kb Memory work properly. According to [the DS2406 docs](https://github.com/owfs/owfs-doc/wiki/DS2406) the DS2406 should not even have an `aux` branch. Alas, mine does and it breaks things.

Perhaps it auto-switches like the [DS2409](http://owfs.org/index.php?page=ds2409) and can be safely ignored as this pull request implements.