### PR TITLE
Support owfs message type 'presence'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ In addition the owserver port and/or host can be specified in **msg.host** and *
 
 To trigger reading sensors periodically, use an Inject node to send messages every X seconds.
 
+To check presence of sensors, select Mode **Presence** and use an Inject node to request the status. A boolean value in **msg.payload** will indicate the sensor presence status.
+
 
 Example
 -------

--- a/owfs.html
+++ b/owfs.html
@@ -31,6 +31,7 @@
         <select id="node-input-mode" style="width:70%">
             <option value="read">Read</option>
             <option value="write">Write</option>
+            <option value="presence">Presence</option>
         </select>
     </div>
     <div class="form-row">
@@ -66,6 +67,7 @@
     <p>If the <a href="http://owfs.org/index.php?page=what-is-uncached">uncached</a> flag is set, then it requests the owfs gets fresh value from the 1-wire device, rather than a recent value.</p>
     <p>Configuration options can be specified in <b>msg.host</b>, <b>msg.port</b> and <b>msg.uncached</b>, overriding any settings in the node configuration.</p>
     <p>To trigger reading sensors periodically, use an Inject node to send messages every X seconds.</p>
+    <p>To check presence of sensors, select Mode <b>Presence</b> and use an Inject node to request the status. A boolean value in <b>msg.payload</b> will indicate the sensor presence status.
 </script>
 
 <script type="text/javascript">
@@ -74,7 +76,7 @@
         defaults: {
             name: {value:""},
             uncached: {value:false},
-            mode: {value:"read",validate:RED.validators.regex(/^read|write$/)},
+            mode: {value:"read",validate:RED.validators.regex(/^read|write|presence$/)},
             host: {value:"localhost"},
             port: {value:4304,validate:RED.validators.regex(/^[0-9]*$/)},
             paths: {value:[]}

--- a/owfs.js
+++ b/owfs.js
@@ -51,7 +51,7 @@ module.exports = function(RED) {
         });
         return r;
     }
-    
+
     function parseResult(result) {
         if (typeof result.match === 'function') {
             if (result.match(/^\-?\d+\.\d+$/)) {
@@ -96,6 +96,7 @@ module.exports = function(RED) {
             var client = new owfs.Client(host, port);
             var clientRead = Promise.promisify(client.read, {context: client});
             var clientWrite = Promise.promisify(client.write, {context: client});
+            var clientPresence = Promise.promisify(client.presence, {context: client});
 
             if (mode == 'write') {
                 var performRequest = function(path) {
@@ -108,6 +109,15 @@ module.exports = function(RED) {
                     });
                 }
                 node.status({fill:"blue", shape:"dot", text:"Writing"});
+            } else if (mode == 'presence') {
+                var performRequest = function(path) {
+                    if (uncached) {
+                        return clientPresence('uncached/' + path);
+                    } else {
+                        return clientPresence(path);
+                    }
+                }
+                node.status({fill:"blue", shape:"dot", text:"Checking presence"});
             } else {
                 var performRequest = function(path) {
                     if (uncached) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url":"https://github.com/njh/node-red-contrib-owfs.git"
     },
     "dependencies": {
-        "owfs": "~0.3.0",
+        "owfs": "~0.4.0",
         "bluebird": "~3.4.6"
     },
     "keywords": [ "1-wire", "owfs", "node-red", "owserver", "DS18B20", "DS18S20" ],


### PR DESCRIPTION
Useful to check the existence of 1-Wire devices like the DS2411.Support 'presence'

Depends on njh/node-owfs#38

If you have any improvements, just let me know.
I would be happy if this change gets accepted.
